### PR TITLE
Added handling for "customDataOverride" node type added in cocosCreat…

### DIFF
--- a/src/merge.cpp
+++ b/src/merge.cpp
@@ -153,6 +153,8 @@ std::string FileRevision::getID(const json& node) const {
 			type = "target";
 		} else if (node.count("data")) {
 			type = "data";
+		} else if (node.count("customDataOverride")) {
+			type = "customDataOverride";
 		}
 
 		if (type.length()) {
@@ -253,3 +255,4 @@ void FileRevision::convertIDToIndex(json& node) {
 		}	
 	}
 }
+


### PR DESCRIPTION
…or 1.4, Merging should work again, it is possible that there are more new unknown types, however.